### PR TITLE
Decode html special character

### DIFF
--- a/src/Exporter/BaseExporter.php
+++ b/src/Exporter/BaseExporter.php
@@ -109,6 +109,8 @@ abstract class BaseExporter implements ExporterInterface
                         $return[$name] = $filesModel->findByPk($row[$name])->path;
                     }
                 }
+                
+                $return[$name] = html_entity_decode($return[$name]);
             }
 
             return \array_values($return);


### PR DESCRIPTION
Special characters like `(` and `)` are stored as `&#40;` and `&#41;` in the database. So these need to be decoded before writing to CSV file.